### PR TITLE
Allowing logging message to be type string

### DIFF
--- a/bin/src/logging.js
+++ b/bin/src/logging.js
@@ -9,7 +9,7 @@ const errorSymbol = process.stderr.isTTY ? `🚨   ` : `Error: `;
 export const stderr = console.error.bind( console ); // eslint-disable-line no-console
 
 function log ( object, symbol ) {
-	const message = object.plugin ? `(${object.plugin} plugin) ${object.message}` : object.message;
+	const message = (object.plugin ? `(${object.plugin} plugin) ${object.message}` : object.message) || object;
 
 	stderr( `${symbol}${chalk.bold( message )}` );
 


### PR DESCRIPTION
Before this change, in plugins like this: 
https://github.com/rollup/rollup-plugin-babel/blob/master/src/index.js#L39
will just get `undefined` in the output.

I haven't have the time to to look very in depth at all the code, but I found a couple of places (both in rollup itself and in external plugins) where the caller is passing a string, so since fixing all the plugins is probably a non-starter, I figure making the API support strings was the easiest.

You might want to change the param name of the function or do a more strict check for strings.

<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->
